### PR TITLE
認証用Lambdaのキャッシュ機能の除去

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -17,6 +17,8 @@ Resources:
         Authorizers:
           LambdaAuthorization:
             FunctionArn: !GetAtt Authorizer.Arn
+            Identity:
+              ReauthorizeEvery: 0
 
   Authorizer:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
同じ認証トークンを、数秒間隔で別環境からAPIにリクエストを投げる際、最初に投げたリクエストには認証が通るが、2回目以降のリクエストには `User is not authorized to access this resource` というエラーを返していました。
これは、認証用Lambdaのキャッシュ機能により、300秒ほど同じ認証結果を返す仕組みが働いていたために、認証用Lambdaのレスポンス結果で指定していた `methodArn` に同じデータが入ってしまっていたことが原因でした。

そこで、キャッシュ時間を0秒に指定することで、キャッシュ機能を無効化することで対応しました。
`methodArn` という制限を除去する、という方針もありましたが、本機能は1ユーザーが短時間で何度も実行することを想定
していないため、キャッシュ機能を無効にしても処理コスト／費用への影響は大きくないと考えています。

https://qiita.com/hassoubeat/items/0add09325fbe664e263e