### PR TITLE
feat: Lambdaメモリサイズの増強

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -63,6 +63,7 @@ Resources:
       Runtime: python3.14
       Architectures:
         - !Ref LambdaArchitecture
+      MemorySize: 256
       Events:
         StartEC2Instance:
           Type: Api

--- a/template.yaml
+++ b/template.yaml
@@ -42,6 +42,7 @@ Resources:
       Runtime: python3.14
       Architectures:
         - !Ref LambdaArchitecture
+      MemorySize: 256
       Environment:
         Variables:
           IS_SKIPPED: !Ref IsSkippedAuthorizer


### PR DESCRIPTION
以前から、既定の128MBでは、Authorizer Lambdaの実行時間が3秒を超えることがあった
メモリサイズを増強することで処理性能が上がるため、まずは倍にして様子を見たい